### PR TITLE
Automatic Deployment with GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,8 +27,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - run: npm ci
-      - run: npm run build
+      - name: Build
+        run: |
+          npm install
+          npm ci
+          npm run build
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,3 +42,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,24 +18,27 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '14'
+          
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-node-
+            ${{ runner.os }}-yarn-
 
       - name: Build
         run: |
-          npm install
-          npm ci
-          npm run build
+          yarn install --frozen-lockfile
+          yarn build
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./public
+          publish_dir: ./build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public


### PR DESCRIPTION
## Brief Description

This Pull Request creates a new GitHub Action called **Deploy to GitHub Pages** which makes the deployment of the project demo to a branch called `gh-pages` automatic when there's a new commit at `main` branch, so GitHub can build the static page on `gh-pages`.

## Why `visual-curriculum` needs a deployment?

~The simple answer is: Why not?~

The complex answer is: Before this Pull Request, the deployment is made by the code owner manually, as I've seen on `gh-pages` @ThiagoAugustoSM manually sends a commit to update the page demonstration, that is not the best option, because it is not flexible to demonstrate, every time that has a new change on `main` branch, the code owner has to make a commit on `gh-pages` branch. 

## How _Deploy to GitHub Pages_ will make a deployment?

The action only works when there's a new push on `main` branch. When that happens, GitHub will build an environment so it can build the project (powered by Linux, Node and Yarn). After Building it we use [peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages) to commit the build to `gh-pages` branch.

## Is there any test that we can see that kind of deployment?

Yes!

You can see the deployment of my fork at <https://steffanop.github.io/visual-curriculum/>.

Look at [workflows/deploy.yml](https://github.com/SteffanoP/visual-curriculum/actions/workflows/deploy.yml) to see all the deployment that was made.

As well, you can see more at my fork at <https://github.com/SteffanoP/visual-curriculum>.